### PR TITLE
ログリストを一回表示すると非表示にしてもタップが後ろに伝搬しない問題を修正

### DIFF
--- a/Dotzu/ManagerViewController.swift
+++ b/Dotzu/ManagerViewController.swift
@@ -37,6 +37,7 @@ class ManagerViewController: UIViewController, LogHeadViewDelegate {
         guard let controller = storyboard.instantiateInitialViewController() else {
             return
         }
+        controller.modalPresentationStyle = .fullScreen
         self.present(controller, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
ManagerControllerのviewWillAppearがcallされないのでタップが後ろに伝搬しない